### PR TITLE
Add apostrophes around default values

### DIFF
--- a/src/components/Label.jsx
+++ b/src/components/Label.jsx
@@ -4,10 +4,10 @@ import { AdvancedMarker, AdvancedMarkerAnchorPoint } from "@vis.gl/react-google-
 
 const LabelContent = ({ mxObject, polygonLabel, labelColor, labelSize, labelClass }) => (
     <div
-        className={labelClass ? labelClass.get(mxObject).value : "polygon-label"}
+        className={labelClass ? labelClass.get(mxObject).value : "'polygon-label'"}
         style={{
-            color: labelColor ? labelColor.get(mxObject).value : "#000",
-            fontSize: labelSize ? labelSize.get(mxObject).value + "px" : "12px"
+            color: labelColor ? labelColor.get(mxObject).value : "'#000'",
+            fontSize: labelSize ? labelSize.get(mxObject).value + "px" : "'12px'"
         }}
     >
         {polygonLabel.get(mxObject).value}


### PR DESCRIPTION
Default values when configuring a label missed an apostrophe around the string value, leading to errors when you first add a label